### PR TITLE
Simpler configuration for production url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the dependencies with bundler
 
 Once you've installed the code you can start a server using jekyll
 
-    $ bundle exec jekyll serve -w -c _config.yml,_config.development.yml
+    $ bundle exec jekyll serve -w
 
 This will start a webserver running at <http://localhost:4000>.
 

--- a/_config.development.yml
+++ b/_config.development.yml
@@ -1,1 +1,0 @@
-url: "http://localhost:4000"

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,6 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://staging.shineyoureye.org"
 twitter_username: NGShineyoureye
 
 # Build settings

--- a/_plugins/production_url.rb
+++ b/_plugins/production_url.rb
@@ -1,0 +1,7 @@
+class ProductionUrl < Jekyll::Generator
+  def generate(site)
+    if Jekyll.env == 'production'
+      site.config['url'] = "//#{File.read('CNAME').chomp}"
+    end
+  end
+end


### PR DESCRIPTION
Rather than having to use a special command to run the site in
development we instead use a plugin which only runs when compiling the
site for production. This plugin simply reads the CNAME file and uses
the contents of that as the site's url.
