### PR TITLE
Show 5 recent blog posts, and 5 placeholder events, on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,24 @@
 ---
 layout: null
+events:
+  - title: An example event
+    date: 2016-01-01
+    url: /info/events
+  - title: Another example event
+    date: 2016-01-02
+    url: /info/events
+  - title: An exciting event
+    date: 2016-01-03
+    url: /info/events
+  - title: "An example event with a very very long title: look how long it is"
+    date: 2016-01-04
+    url: /info/events
+  - title: An example event
+    date: 2016-01-05
+    url: /info/events
+  - title: An example event
+    date: 2016-01-06
+    url: /info/events
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -45,8 +64,6 @@ layout: null
   </div>
 </div>
 
-
-
 <div style=" padding: 4rem 0 0; background: #bbf6d7 ;">
     <div class="container">
         <div class="row">
@@ -88,35 +105,28 @@ layout: null
 <div style=" padding: 4rem 0 4rem; ">
     <div class="container">
         <div class="row">
-         <div class="six columns">
-         <h4><b><a href="{{ site.url }}{{ site.baseurl }}/blog/">News</a></b></h4>
-         <h5>Get updates on top stories, weekly reviews of what your representatives have been doing, blogs and more!</h5>
-
-          </div>
-          <div class="six columns">
-          <h4><b><a href="{{ site.url }}{{ site.baseurl }}/info/democracy-resources">Resources</a></b></h4>
-         <h5>Be an #ActiveCitizen. Know your rights! Get access to resources that can help you engage your representatives.</h5>
-
-          </div>
+            <div class="six columns">
+                <h4><b><a href="{{ site.url }}{{ site.baseurl }}/blog/">News</a></b></h4>
+              {% for post in site.posts limit:5 %}
+                <h5 style="font-weight: inherit;">
+                    <a style="display: block;" href="{{ post.url }}">{{ post.title }}</a>
+                    <small style="display: block; font-size: 0.7em;">{{ post.date | date: "%-d %B %Y" }}</small>
+                </h5>
+              {% endfor %}
+            </div>
+            <div class="six columns">
+                <h4><b><a href="{{ site.url }}{{ site.baseurl }}/info/events">Events</a></b></h4>
+              {% for event in page.events limit:5 %}
+                <h5 style="font-weight: inherit;">
+                    <a style="display: block;" href="{{ post.url }}">{{ event.title }}</a>
+                    <small style="display: block; font-size: 0.7em;">{{ event.date | date: "%-d %B %Y" }}</small>
+                </h5>
+              {% endfor %}
+           </div>
         </div>
-  </div>
-
-        <p>&nbsp;</p>
-
-  <div class="container">
-        <div class="row">
-         <div class="six columns">
-         <h4><b><a href="{{ site.url }}{{ site.baseurl }}/info/elections">Elections</a></b></h4>
-         <h5>Elections help you decide your representatives. Access our <a href="{{ site.url }}{{ site.baseurl }}/info/elections">Election Timetable</a> and get more information on voting and the electoral process.</h5>
-          </div>
-          <div class="six columns">
-          <h4><b><a href="{{ site.url }}{{ site.baseurl }}/info/events">Events</a></b></h4>
-         <h5>Participate and join other #ActiveCitizens at events to learn, lend your voice and engage your representatives.</h5>
-
-          </div>
-        </div>
-  </div>
+    </div>
 </div>
+
 
 <div style=" padding: 5rem 0 4rem; background: #bbf6d7 ; ">
     <div class="container">


### PR DESCRIPTION
Fixes #32.

The blog posts are pulled from the Jekyll posts list, but the events are hard-coded at the top of the page for now.

![screen shot 2016-04-18 at 12 01 57](https://cloud.githubusercontent.com/assets/739624/14602017/62ee5546-055d-11e6-868a-145dcfbc25e4.png)
