### PR TITLE
Share main menu markup and styling between homepage and rest of site

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,3 @@ DEPENDENCIES
   jekyll-search!
   puma
   rack-jekyll
-
-BUNDLED WITH
-   1.11.2

--- a/_compass/_nigeria_overrides.scss
+++ b/_compass/_nigeria_overrides.scss
@@ -1,34 +1,4 @@
-#main-menu {
-  background: #8DC5EB; // light blue
-  border-bottom: 2px solid #4082AF; // rich, dark blue
-
-  nav {
-    position:relative;
-    z-index:2;
-    text-align: right;
-
-    ul {
-      li {
-        border-right: 2px solid transparent;
-
-         a {
-          color: $colour_black;
-          background-image: none;
-
-          &:hover {
-            background: #C3E3F8;
-          }
-        }
-
-        &:hover ul li a:hover {
-          background: #C3E3F8;
-        }
-      }
-    }
-  }
-}
-
-
+@import 'menu';
 
 html{
   background-color: $colour_white;

--- a/_compass/core/_menu.scss
+++ b/_compass/core/_menu.scss
@@ -7,7 +7,6 @@
     display: block; }
   @media print { display: none; }
   background: $colour_black;
-  @include background(linear-gradient($colour_black, $colour_blackish / 1.4));
   nav {
     width: 100%;
     text-align: center;
@@ -31,10 +30,8 @@
           color: $colour_white;
           background: $colour_black;
           border-bottom: 0;
-          @include background(linear-gradient($colour_black, $colour_blackish / 1.4));
           &:hover {
-            background: $colour_blackish;
-            @include background(linear-gradient($colour_blackish / 1.4, $colour_black)); } }
+            background: $colour_blackish; } }
         &:last-child {
           border-right: 0; }
         ul {
@@ -70,7 +67,7 @@
                 float: none;
                 &:hover {
                   background: #d4d4d4; } } } } }
-        @media only all and (min-width: 720px), print { 
+        @media only all and (min-width: 720px), print {
           & {
             a {
               font-size: 14px;
@@ -93,13 +90,13 @@
 #footer-menu {
   // by default show the sub entries. Hide if the screen is big in which
   // case the menu at the top will be shown instead.
-  li > ul { 
+  li > ul {
     @media only all and (min-width: 640px), print {
       display: none;
     }
-    
+
     margin-left: 1em;
-    
+
     li {
       display: inline;
       font-size: 90%;

--- a/_compass/menu.scss
+++ b/_compass/menu.scss
@@ -1,0 +1,44 @@
+// Menu styles are put in their own top-level SCSS file
+// so that they can be compiled straight to CSS for the
+// homepage, and @imported into _nigeria_overrides.scss
+// for the rest of the site.
+
+// The homepage needs the styles from core/menu, which
+// itself needs all the mixins and variables from core.
+// So we have to import the lot, even if that means the
+// files are imported twice when this file is @imported
+// into _nigeria_overrides.scss :-(
+@import 'core/core';
+@import 'core/colours_default';
+@import 'colours_nigeria';
+@import 'core/menu';
+
+#main-menu {
+  background: #8DC5EB; // light blue
+  border-bottom: 2px solid #4082AF; // rich, dark blue
+
+  nav {
+    position:relative;
+    z-index:2;
+    text-align: right;
+
+    ul {
+      li {
+        border-right: 2px solid transparent;
+
+         a {
+          color: black;
+          background: transparent;
+
+          &:hover {
+            background: #C3E3F8;
+          }
+        }
+
+        &:hover ul li a:hover {
+          background: #C3E3F8;
+        }
+      }
+    }
+  }
+}

--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -1,5 +1,5 @@
 <div id="main-menu">
-  <nav class="wrapper">
+  <nav class="wrapper container">
     <ul>
 
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@ events:
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <link rel="stylesheet" href="http://www.eie.ng/syedemo/css/normalize.css">
   <link rel="stylesheet" href="http://www.eie.ng/syedemo/css/skeleton.css">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/menu.css">
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
@@ -51,6 +52,7 @@ events:
 </head>
 <body>
 
+  {% include main_menu.html %}
 
 <div style=" padding: 5rem 0 4rem;">
   <div class="container">


### PR DESCRIPTION
Since the styles for the homepage are completely separate from the styles for the rest of the site, the shared menu required some slightly unintuitive SCSS `@imports`.

But it’s still more sensible than duplicating all the menu styling, once for the homepage and once for the rest of the site.

Fixes #34.

![screen shot 2016-05-26 at 11 43 39](https://cloud.githubusercontent.com/assets/739624/15572232/2c2de286-2337-11e6-9db4-3a28e7009c53.png)
