### PR TITLE
Hide example events

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,24 +1,6 @@
 ---
 layout: null
-events:
-  - title: An example event
-    date: 2016-01-01
-    url: /info/events
-  - title: Another example event
-    date: 2016-01-02
-    url: /info/events
-  - title: An exciting event
-    date: 2016-01-03
-    url: /info/events
-  - title: "An example event with a very very long title: look how long it is"
-    date: 2016-01-04
-    url: /info/events
-  - title: An example event
-    date: 2016-01-05
-    url: /info/events
-  - title: An example event
-    date: 2016-01-06
-    url: /info/events
+events: []
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -113,6 +95,8 @@ events:
                     <a style="display: block;" href="{{ post.url }}">{{ event.title }}</a>
                     <small style="display: block; font-size: 0.7em;">{{ event.date | date: "%-d %B %Y" }}</small>
                 </h5>
+              {% else %}
+                <p>There are no upcoming events.</p>
               {% endfor %}
            </div>
         </div>


### PR DESCRIPTION
For now just have a message on the homepage saying there are no upcoming
events. We can add events in the future.
