### PR TITLE
Limiting posts in Events and News to 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ events: []
         <div class="row">
             <div class="six columns">
                 <h4><b><a href="{{ site.url }}{{ site.baseurl }}/blog/">News</a></b></h4>
-              {% for post in site.posts limit:5 %}
+              {% for post in site.posts limit:3 %}
                 <h5 style="font-weight: inherit;">
                     <a style="display: block;" href="{{ post.url }}">{{ post.title }}</a>
                     <small style="display: block; font-size: 0.7em;">{{ post.date | date: "%-d %B %Y" }}</small>
@@ -90,7 +90,7 @@ events: []
             </div>
             <div class="six columns">
                 <h4><b><a href="{{ site.url }}{{ site.baseurl }}/info/events">Events</a></b></h4>
-              {% for event in page.events limit:5 %}
+              {% for event in page.events limit:3 %}
                 <h5 style="font-weight: inherit;">
                     <a style="display: block;" href="{{ post.url }}">{{ event.title }}</a>
                     <small style="display: block; font-size: 0.7em;">{{ event.date | date: "%-d %B %Y" }}</small>


### PR DESCRIPTION
Although SYE originally only asked to limit news posts having events set to 5 would leave the section unbalanced once they start adding events so I've also changed this to only allow 3

Closes #50 
